### PR TITLE
Remove deprecated :host selector

### DIFF
--- a/styles/wallaby.atom-text-editor.less
+++ b/styles/wallaby.atom-text-editor.less
@@ -1,6 +1,6 @@
 @import "wallaby-vars";
 
-.atom-text-editor, :host, atom-text-editor {
+.atom-text-editor, atom-text-editor {
 
   .line {
     &.wlc::after {


### PR DESCRIPTION
Atom has deprecated the `:host` selector, but currently automatically translates any rules that contain either the `:host` or `:shadow` selector. In the case of `atom-wallaby` it converts all the existing `:host` rules to `atom-text-editor` rules, but the stylesheet already contains rules for `atom-text-editor` so we only need to delete `:host`.

![screen shot 2017-01-23 at 10 31 25](https://cloud.githubusercontent.com/assets/26238/22200707/246183c0-e158-11e6-82cc-ff4e3edbfcb0.png)
